### PR TITLE
fixed typos in schema and settings ui

### DIFF
--- a/src/net.milgar.budgie-pixel-saver.gschema.xml
+++ b/src/net.milgar.budgie-pixel-saver.gschema.xml
@@ -14,11 +14,11 @@
     <key type="b" name="hide-for-csd">
       <default>false</default>
       <summary>Hide if window is CSD</summary>
-      <description>Whether to hide applet if window is Client Side Decoreted</description>
+      <description>Whether to hide applet if window is Client Side Decorated</description>
     </key>
     <key type="b" name="hide-for-unmaximized">
       <default>false</default>
-      <summary>Hide if window is unmaximixed</summary>
+      <summary>Hide if window is unmaximized</summary>
       <description>Whether to hide applet if window is unmaximized</description>
     </key>
   </schema>

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -67,7 +67,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">Hide for Client Side Decoreted windows</property>
+        <property name="label" translatable="yes">Hide for Client Side Decorated windows</property>
         <property name="wrap">True</property>
         <property name="xalign">0</property>
       </object>


### PR DESCRIPTION
fixed a visual typo in settings as well as in the schema descriptions