### PR TITLE
 Set no relief to window control button

### DIFF
--- a/src/BudgiePixelSaverApplet.vala
+++ b/src/BudgiePixelSaverApplet.vala
@@ -43,8 +43,13 @@ public class Applet : Budgie.Applet
         this.title_bar_manager.register();
 
         this.minimize_button = new Gtk.Button.from_icon_name ("window-minimize-symbolic");
+        this.minimize_button.relief = Gtk.ReliefStyle.NONE;
+
         this.maximize_button = new Gtk.Button.from_icon_name ("window-maximize-symbolic");
+        this.maximize_button.relief = Gtk.ReliefStyle.NONE;
+
         this.close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", Gtk.IconSize.BUTTON);
+        this.close_button.relief = Gtk.ReliefStyle.NONE;
 
         this.maximize_image = new Gtk.Image.from_icon_name ("window-maximize-symbolic", Gtk.IconSize.BUTTON);
         this.restore_image = new Gtk.Image.from_icon_name ("window-restore-symbolic", Gtk.IconSize.BUTTON);

--- a/src/BudgiePixelSaverApplet.vala
+++ b/src/BudgiePixelSaverApplet.vala
@@ -64,7 +64,6 @@ public class Applet : Budgie.Applet
         this.applet_container.pack_start (this.close_button, false, false, 0);
         this.add (this.applet_container);
 
-        this.set_css_styles();
 
         event_box.button_press_event.connect ((event) => {
             if (event.type == Gdk.EventType.@2BUTTON_PRESS){
@@ -138,19 +137,6 @@ public class Applet : Budgie.Applet
 
     ~Applet(){
         this.title_bar_manager.unregister();
-    }
-
-    private void set_css_styles(){
-        this.applet_container.get_style_context().add_class("titlebar");
-
-        this.minimize_button.get_style_context().add_class("titlebutton");
-        this.minimize_button.get_style_context().add_class("minimize");
-
-        this.maximize_button.get_style_context().add_class("titlebutton");
-        this.maximize_button.get_style_context().add_class("maximize");
-
-        this.close_button.get_style_context().add_class("titlebutton");
-        this.close_button.get_style_context().add_class("close");
     }
 
     void on_settings_change(string key) {


### PR DESCRIPTION
Fixed #16. Also it plays nice with panel look and feel. Tested on built-in theme and [Qogir theme](https://github.com/vinceliuice/Qogir-theme).

Before - built-in theme:
![image](https://user-images.githubusercontent.com/10938708/45574105-16649e00-b899-11e8-8ee3-cd0cf4eb3bd9.png)

After - built-in theme:
![image](https://user-images.githubusercontent.com/10938708/45574041-cede1200-b898-11e8-97a3-a88ded4b10bc.png)

Before - Qogir theme:
![image](https://user-images.githubusercontent.com/10938708/45573818-fda7b880-b897-11e8-8de5-4b5965bc3d1b.png)

After - Qogir theme:
![image](https://user-images.githubusercontent.com/10938708/45573877-292aa300-b898-11e8-8d40-ef0687fb60b9.png)
